### PR TITLE
Inclui prefixo para localização de definições chart/

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,4 +21,3 @@ runs:
       env:
         ENVIRONMENT: ${{ inputs.environment }}
         BOOTSTRAP_TOKEN: ${{ inputs.token }}
-

--- a/action.yaml
+++ b/action.yaml
@@ -11,10 +11,6 @@ inputs:
   githubToken:
     description: "Depreciado, não usar."
     required: false
-  chartPrefix:
-    description: "Prefixo para a localização das definições do Helm. É necessário incluir uma '/' no final do caminho"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -25,4 +21,4 @@ runs:
       env:
         ENVIRONMENT: ${{ inputs.environment }}
         BOOTSTRAP_TOKEN: ${{ inputs.token }}
-        CHART_PREFIX: ${{ inputs.chartPrefix }}
+

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
     description: "Depreciado, não usar."
     required: false
   chartPrefix:
-    description: "Prefixo para a localização das definições do Helm."
+    description: "Prefixo para a localização das definições do Helm. É necessário incluir uma '/' no final do caminho"
     required: false
     default: ""
 

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,10 @@ inputs:
   githubToken:
     description: "Depreciado, não usar."
     required: false
+  chartPrefix:
+    description: "Prefixo para a localização das definições do Helm."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -21,3 +25,4 @@ runs:
       env:
         ENVIRONMENT: ${{ inputs.environment }}
         BOOTSTRAP_TOKEN: ${{ inputs.token }}
+        CHART_PREFIX: ${{ inputs.chartPrefix }}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 # be set to "monorepo" in order to the pipeline work properly.
 sub_dir="./"
 if [[ "$PIPELINE_MODE" == "monorepo" ]]; then
-  sub_dir="$REPOSITORY"
+  sub_dir="$CHART_PREFIX$REPOSITORY"
 fi
 
 # Setup Helm if needed.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,7 @@ set -e
 sub_dir="./"
 if [[ "$PIPELINE_MODE" == "monorepo" ]]; then
   if [[ -z ${REPOSITORY_PATH} ]]; then
-    $REPOSITORY_PATH = ""
+    REPOSITORY_PATH=""
   fi
   sub_dir="$REPOSITORY_PATH$REPOSITORY"
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,10 @@ set -e
 # be set to "monorepo" in order to the pipeline work properly.
 sub_dir="./"
 if [[ "$PIPELINE_MODE" == "monorepo" ]]; then
-  sub_dir="$CHART_PREFIX$REPOSITORY"
+  if [[ -z ${REPOSITORY_PATH} ]]; then
+    $REPOSITORY_PATH = ""
+  fi
+  sub_dir="$REPOSITORY_PATH$REPOSITORY"
 fi
 
 # Setup Helm if needed.


### PR DESCRIPTION
**Contexto:** Eu @diegohd87  e @eucleciojosias em um conversa percebemos que o monorepo do [student-journey-client](https://github.com/betrybe/student-journey-client) tem uma estrututra diferente do [go-trybe](https://github.com/betrybe/go-trybe). Isso porque no `go-trybe` os pacotes estão direto na raiz, enquanto que no `student-journey-client` existe um diretório `namespaces/student-journey`.
**Problema:** Na _action_ de _bootstrap_, caso seja um monorepo o subdiretório é definido como o nome do pacote dentro do projeto, o problema é que hoje não é considerado um prefixo para definir o subdiretório.
Esta PR resolve este problema de prefixos